### PR TITLE
Fix options getter

### DIFF
--- a/Source/SlideMenuController.m
+++ b/Source/SlideMenuController.m
@@ -168,7 +168,7 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
     [self addRightGestures];
 }
 
--(SlideMenuOption *)getOption {
+-(SlideMenuOption *)option {
     return options;
 }
 


### PR DESCRIPTION
The example code in the README for setting options is not working:

```
self.slideMenuController.option.leftViewWitdth = 50;
self.slideMenuController.option.contentViewScale = 0.5;
```

This is caused by the getter for the `option` property being named `getOption`. Getter methods should not be prefixed.
