### PR TITLE
Remove duplicate category

### DIFF
--- a/Source/SlideMenuController.h
+++ b/Source/SlideMenuController.h
@@ -126,7 +126,7 @@ typedef enum {
 
 @interface UIViewController(SlideMenuVC)
 
--(SlideMenuController *)slideMenuController;
+@property (retain, nonatomic, readonly) SlideMenuController *slideMenuController;
 
 -(void)addLeftBarButtonWithImage:(UIImage *)buttonImage;
 

--- a/Source/SlideMenuController.m
+++ b/Source/SlideMenuController.m
@@ -984,13 +984,6 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
 @end
 
 
-@interface UIViewController(SlideMenuVC)
-
-@property (retain, nonatomic, readonly, getter=slideMenuController) SlideMenuController *slideMenuController;
-
-
-@end
-
 @implementation UIViewController(SlideMenuVC)
 
 -(SlideMenuController *)slideMenuController {


### PR DESCRIPTION
If I haven't misunderstood what the category `UIViewController+SlideMenuVC` is trying to achieve it appears to have been defined twice. This results in a warning in xcode. I've moved the definition of the `slideMenuController`-property to the header-file and removed the duplicate category.
