### PR TITLE
fix left and right view width

### DIFF
--- a/Source/SlideMenuController.m
+++ b/Source/SlideMenuController.m
@@ -79,6 +79,7 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
         _leftContainerView = [UIView new];
         _rightContainerView = [UIView new];
         options = [[SlideMenuOption alloc] init];
+        [options addObserver:self forKeyPath:@"leftViewWitdth" options:NSKeyValueObservingOptionNew context:nil];
     }
     return self;
 }
@@ -174,6 +175,28 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
 
 -(void)setOption:(SlideMenuOption *)option {
     options = option;
+    [options addObserver:self forKeyPath:@"leftViewWitdth" options:NSKeyValueObservingOptionNew context:nil];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
+{
+    if (object == options) {
+        if ([keyPath isEqualToString:@"leftViewWitdth"]) {
+            CGRect leftFrame = _leftContainerView.frame;
+            NSNumber *newWidth = [change objectForKey:NSKeyValueChangeNewKey];
+            leftFrame.size.width = [newWidth floatValue];
+            _leftContainerView.frame = leftFrame;
+            return;
+        }
+        
+        if ([keyPath isEqualToString:@"rightViewWidth"]) {
+            CGRect rightFrame = _rightContainerView.frame;
+            NSNumber *newWidth = [change objectForKey:NSKeyValueChangeNewKey];
+            rightFrame.size.width = [newWidth floatValue];
+            _rightContainerView.frame = rightFrame;
+            return;
+        }
+    }
 }
 
 


### PR DESCRIPTION
It seems that SlideMenuController has no chance to update the leftContainerView's width when I use the code as follows to set leftContainerView's width. 

```
    SlideMenuController *smc = [[SlideMenuController alloc] initWithMainViewController:mnvc leftMenuViewController:svc];

    smc.option.leftViewWitdth = CGRectGetWidth(smc.view.bounds) * 0.723;
```

So When leftSlideMenu opened, the frame.size and origin.x don't correspond.

抱歉，我的英语不好。
就是我用上面的代码设置了左边栏的宽度后，如果宽度设置的比以前小，打开左边栏后不能完全收回去。因为计算origin.x时用的是新设置的宽度，而左边栏的宽度还是原来的宽度。
