### PR TITLE
Move setup of child controllers to initView

### DIFF
--- a/Source/SlideMenuController.m
+++ b/Source/SlideMenuController.m
@@ -123,6 +123,7 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
 }
 
 -(void)awakeFromNib {
+    [super awakeFromNib];
     [self initView];
 }
 

--- a/Source/SlideMenuController.m
+++ b/Source/SlideMenuController.m
@@ -167,6 +167,10 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
     
     [self addLeftGestures];
     [self addRightGestures];
+
+    [self setUpViewController:_mainContainerView targetViewController:_mainViewController];
+    [self setUpViewController:_leftContainerView targetViewController:_leftViewController];
+    [self setUpViewController:_rightContainerView targetViewController:_rightViewController];
 }
 
 -(SlideMenuOption *)option {
@@ -230,12 +234,6 @@ static UIGestureRecognizerState RPSLastState = UIGestureRecognizerStateEnded;
         return [_mainViewController supportedInterfaceOrientations];
     }
     return UIInterfaceOrientationMaskAll;
-}
-
--(void)viewWillLayoutSubviews {
-    [self setUpViewController:_mainContainerView targetViewController:_mainViewController];
-    [self setUpViewController:_leftContainerView targetViewController:_leftViewController];
-    [self setUpViewController:_rightContainerView targetViewController:_rightViewController];
 }
 
 -(void)openLeft {


### PR DESCRIPTION
It is too late to add child view controllers in `viewWillLayoutSubviews`. Stuff like `topLayoutGuide` on child view controllers will not be set correctly in their `viewDidLoad`-methods causing issues with auto layout. I've moved the `setUpViewController`-calls to `initView` and can't see any issues with having them made there.
